### PR TITLE
fix: replace `as const` with typed manifest exports

### DIFF
--- a/forge/src/generators/manifest-generator.test.ts
+++ b/forge/src/generators/manifest-generator.test.ts
@@ -87,7 +87,7 @@ describe('generateManifests', () => {
 
     it('handles empty sources array', () => {
       const manifest = generateManifests(buildConfig())['source-manifest.ts'];
-      expect(manifest).toContain('export const sourceConfigs = []');
+      expect(manifest).toContain('export const sourceConfigs: SourceConfig[] = []');
       expect(manifest).not.toContain('RSSSource');
     });
   });
@@ -117,7 +117,7 @@ describe('generateManifests', () => {
 
     it('handles empty layers array', () => {
       const manifest = generateManifests(buildConfig())['layer-manifest.ts'];
-      expect(manifest).toContain('export const layerConfigs = []');
+      expect(manifest).toContain('export const layerConfigs: LayerConfig[] = []');
       expect(manifest).not.toContain('PointsLayerPlugin');
     });
   });
@@ -143,7 +143,7 @@ describe('generateManifests', () => {
 
     it('handles empty panels array', () => {
       const manifest = generateManifests(buildConfig())['panel-manifest.ts'];
-      expect(manifest).toContain('export const panelConfigs = []');
+      expect(manifest).toContain('export const panelConfigs: PanelConfig[] = []');
     });
   });
 
@@ -178,9 +178,9 @@ describe('generateManifests', () => {
       return matches.map(m => m[1]);
     }
 
-    // Helper: extract the JSON array from "export const xxxConfigs = [...] as const;"
+    // Helper: extract the JSON array from "export const xxxConfigs: Type[] = [...];"
     function extractExportedJson(code: string, varName: string): unknown[] {
-      const match = code.match(new RegExp(`export const ${varName} = (\\[[\\s\\S]*?\\]) as const;`));
+      const match = code.match(new RegExp(`export const ${varName}:\\s*\\w+\\[\\]\\s*=\\s*(\\[[\\s\\S]*?\\]);`));
       if (!match) throw new Error(`Could not extract ${varName} from generated code`);
       return JSON.parse(match[1]);
     }
@@ -363,17 +363,29 @@ describe('generateManifests', () => {
       expect(parsed.map(p => p.name)).toEqual(['feed', 'brief']);
     });
 
-    // as const suffix
-    it('config arrays end with "as const"', () => {
+    // typed exports
+    it('config arrays use typed exports instead of as const', () => {
       const config = buildConfig({
         sources: [{ name: 'r', type: 'rss', url: 'https://a.com/rss', category: 'n', tier: 3, interval: 300, language: 'en', tags: [] }],
         layers: [{ name: 'p', type: 'points', displayName: 'P', color: '#FF0000', data: { source: 'static', path: 'f.geojson' }, defaultVisible: false, category: 'c' }],
         panels: [{ name: 'f', type: 'news-feed', displayName: 'F', position: 0, config: {} }],
       });
       const manifests = generateManifests(config);
-      expect(manifests['source-manifest.ts']).toMatch(/sourceConfigs = \[[\s\S]*?\] as const;/);
-      expect(manifests['layer-manifest.ts']).toMatch(/layerConfigs = \[[\s\S]*?\] as const;/);
-      expect(manifests['panel-manifest.ts']).toMatch(/panelConfigs = \[[\s\S]*?\] as const;/);
+      expect(manifests['source-manifest.ts']).toMatch(/sourceConfigs: SourceConfig\[\] = \[[\s\S]*?\];/);
+      expect(manifests['layer-manifest.ts']).toMatch(/layerConfigs: LayerConfig\[\] = \[[\s\S]*?\];/);
+      expect(manifests['panel-manifest.ts']).toMatch(/panelConfigs: PanelConfig\[\] = \[[\s\S]*?\];/);
+    });
+
+    it('manifests import the correct type definitions', () => {
+      const config = buildConfig({
+        sources: [{ name: 'r', type: 'rss', url: 'https://a.com/rss', category: 'n', tier: 3, interval: 300, language: 'en', tags: [] }],
+        layers: [{ name: 'p', type: 'points', displayName: 'P', color: '#FF0000', data: { source: 'static', path: 'f.geojson' }, defaultVisible: false, category: 'c' }],
+        panels: [{ name: 'f', type: 'news-feed', displayName: 'F', position: 0, config: {} }],
+      });
+      const manifests = generateManifests(config);
+      expect(manifests['source-manifest.ts']).toContain("import type { SourceConfig } from '../core/sources/SourceBase.js';");
+      expect(manifests['layer-manifest.ts']).toContain("import type { LayerConfig } from '../core/map/LayerBase.js';");
+      expect(manifests['panel-manifest.ts']).toContain("import type { PanelConfig } from '../core/panels/PanelBase.js';");
     });
   });
 
@@ -383,7 +395,7 @@ describe('generateManifests', () => {
 
   describe('config-to-code contract', () => {
     function extractExportedJson(code: string, varName: string): unknown[] {
-      const match = code.match(new RegExp(`export const ${varName} = (\\[[\\s\\S]*?\\]) as const;`));
+      const match = code.match(new RegExp(`export const ${varName}:\\s*\\w+\\[\\]\\s*=\\s*(\\[[\\s\\S]*?\\]);`));
       if (!match) throw new Error(`Could not extract ${varName}`);
       return JSON.parse(match[1]);
     }

--- a/forge/src/generators/manifest-generator.ts
+++ b/forge/src/generators/manifest-generator.ts
@@ -28,6 +28,7 @@ function generateSourceManifest(config: MonitorForgeConfig): string {
   }
 
   imports.add("import { registerSource } from '../core/sources/source-registry.js';");
+  imports.add("import type { SourceConfig } from '../core/sources/SourceBase.js';");
 
   const sourceTypes = new Set(config.sources.map(s => s.type));
   if (sourceTypes.has('rss')) registrations.push("registerSource('rss', RSSSource);");
@@ -39,7 +40,7 @@ ${Array.from(imports).join('\n')}
 
 ${registrations.join('\n')}
 
-export const sourceConfigs = ${JSON.stringify(config.sources, null, 2)} as const;
+export const sourceConfigs: SourceConfig[] = ${JSON.stringify(config.sources, null, 2)};
 `;
 }
 
@@ -47,6 +48,7 @@ function generateLayerManifest(config: MonitorForgeConfig): string {
   const layerTypes = new Set(config.layers.map(l => l.type));
   const imports: string[] = [
     "import { registerLayerType } from '../core/map/layer-registry.js';",
+    "import type { LayerConfig } from '../core/map/LayerBase.js';",
   ];
 
   if (layerTypes.has('points')) {
@@ -77,7 +79,7 @@ ${imports.join('\n')}
 
 ${registrations.join('\n')}
 
-export const layerConfigs = ${JSON.stringify(config.layers, null, 2)} as const;
+export const layerConfigs: LayerConfig[] = ${JSON.stringify(config.layers, null, 2)};
 `;
 }
 
@@ -85,6 +87,7 @@ function generatePanelManifest(config: MonitorForgeConfig): string {
   const panelTypes = new Set(config.panels.map(p => p.type));
   const imports: string[] = [
     "import { registerPanelType } from '../core/panels/panel-registry.js';",
+    "import type { PanelConfig } from '../core/panels/PanelBase.js';",
   ];
 
   const typeMap: Record<string, string> = {
@@ -114,7 +117,7 @@ ${imports.join('\n')}
 
 ${registrations.join('\n')}
 
-export const panelConfigs = ${JSON.stringify(config.panels, null, 2)} as const;
+export const panelConfigs: PanelConfig[] = ${JSON.stringify(config.panels, null, 2)};
 `;
 }
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -38,7 +38,7 @@ export class App {
     await import('./generated/source-manifest.js');
     const { sourceConfigs } = await import('./generated/source-manifest.js');
     this.sourceManager = new SourceManager();
-    this.sourceManager.initialize(sourceConfigs as unknown as any[]);
+    this.sourceManager.initialize(sourceConfigs);
 
     // Initialize map
     const mapContainer = document.getElementById('forge-map')!;
@@ -49,7 +49,7 @@ export class App {
     await import('./generated/layer-manifest.js');
     const { layerConfigs } = await import('./generated/layer-manifest.js');
     for (const layerConfig of layerConfigs) {
-      await this.mapEngine.addLayer(layerConfig as any);
+      await this.mapEngine.addLayer(layerConfig);
     }
 
     // Initialize panels
@@ -57,7 +57,7 @@ export class App {
     const { panelConfigs } = await import('./generated/panel-manifest.js');
     const sidebar = document.getElementById('forge-sidebar')!;
     this.panelManager = new PanelManager(sidebar);
-    this.panelManager.initialize(panelConfigs as unknown as any[]);
+    this.panelManager.initialize(panelConfigs);
 
     // Initialize AI
     this.aiManager = new AIManager(config.ai as AIConfig);

--- a/test/presets-pipeline.test.ts
+++ b/test/presets-pipeline.test.ts
@@ -21,7 +21,7 @@ function extractRegisteredClasses(code: string): string[] {
 }
 
 function extractExportedJson(code: string, varName: string): unknown[] {
-  const match = code.match(new RegExp(`export const ${varName} = (\\[[\\s\\S]*?\\]) as const;`));
+  const match = code.match(new RegExp(`export const ${varName}:\\s*\\w+\\[\\]\\s*=\\s*(\\[[\\s\\S]*?\\]);`));
   if (!match) throw new Error(`Could not extract ${varName}`);
   return JSON.parse(match[1]);
 }


### PR DESCRIPTION
## Summary

- Replace `as const` assertions in manifest generator with typed exports (`SourceConfig[]`, `LayerConfig[]`, `PanelConfig[]`) and proper type imports
- Remove all 3 unsafe `any` casts from `App.ts` (lines 41, 52, 60) — no longer needed since manifests now export correctly typed arrays
- Update test assertions and regex helpers to match the new export format

Closes #5

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npm test` — 423 tests pass (26 files)
- [x] `grep -n 'as any\|as unknown' src/App.ts` — no matches
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)