### PR TITLE
feat: source resilience — health tracking, backoff, RSS parser upgrade

### DIFF
--- a/api/news/v1/index.test.ts
+++ b/api/news/v1/index.test.ts
@@ -200,6 +200,94 @@ describe('news/v1 handler', () => {
       expect(body.items[0].title).not.toContain('/etc/passwd');
     });
 
+    it('extracts enclosure URL from RSS item', async () => {
+      const enclosureXml = `<?xml version="1.0"?>
+      <rss version="2.0"><channel>
+        <item>
+          <title>Podcast Episode</title>
+          <link>https://example.com/ep1</link>
+          <guid>enc-1</guid>
+          <enclosure url="https://example.com/audio.mp3" type="audio/mpeg" length="12345" />
+        </item>
+      </channel></rss>`;
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(enclosureXml, { status: 200 }),
+      );
+      const request = new Request('https://example.com/api/news/v1?feeds=https://feed.example.com/enc');
+      const response = await handler(request);
+      expect(response.status).toBe(200);
+      const body = await response.json() as { items: Array<{ enclosure?: { url: string } }> };
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].enclosure?.url).toBe('https://example.com/audio.mp3');
+    });
+
+    it('extracts media:thumbnail URL', async () => {
+      const mediaXml = `<?xml version="1.0"?>
+      <rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+        <channel>
+          <item>
+            <title>Article with thumbnail</title>
+            <link>https://example.com/thumb-article</link>
+            <guid>media-1</guid>
+            <media:thumbnail url="https://example.com/thumb.jpg" />
+          </item>
+        </channel>
+      </rss>`;
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(mediaXml, { status: 200 }),
+      );
+      const request = new Request('https://example.com/api/news/v1?feeds=https://feed.example.com/media');
+      const response = await handler(request);
+      expect(response.status).toBe(200);
+      const body = await response.json() as { items: Array<{ thumbnail?: string }> };
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].thumbnail).toBe('https://example.com/thumb.jpg');
+    });
+
+    it('decodes HTML entities in content', async () => {
+      const entityXml = `<?xml version="1.0"?>
+      <rss version="2.0"><channel>
+        <item>
+          <title>Breaking &amp; Latest</title>
+          <link>https://example.com/entities</link>
+          <guid>ent-1</guid>
+          <description>Stocks &lt;rise&gt; &amp; bonds fall</description>
+        </item>
+      </channel></rss>`;
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(entityXml, { status: 200 }),
+      );
+      const request = new Request('https://example.com/api/news/v1?feeds=https://feed.example.com/entity');
+      const response = await handler(request);
+      expect(response.status).toBe(200);
+      const body = await response.json() as { items: Array<{ title: string; description: string }> };
+      expect(body.items[0].title).toBe('Breaking & Latest');
+      expect(body.items[0].description).toContain('Stocks <rise>');
+    });
+
+    it('selects alternate link from Atom entry with multiple links', async () => {
+      const multiLinkAtom = `<?xml version="1.0"?>
+      <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>Multi-Link Feed</title>
+        <entry>
+          <title>Multi Link Entry</title>
+          <link rel="self" href="https://example.com/self" />
+          <link rel="alternate" href="https://example.com/alternate" />
+          <id>ml-1</id>
+          <published>2024-01-01T12:00:00Z</published>
+        </entry>
+      </feed>`;
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        new Response(multiLinkAtom, { status: 200 }),
+      );
+      const request = new Request('https://example.com/api/news/v1?feeds=https://feed.example.com/multilink');
+      const response = await handler(request);
+      expect(response.status).toBe(200);
+      const body = await response.json() as { items: Array<{ link: string }> };
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].link).toBe('https://example.com/alternate');
+    });
+
     it('handles multiple feeds with mixed success', async () => {
       vi.spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce(new Response(sampleRSS, { status: 200 }))

--- a/api/news/v1/index.ts
+++ b/api/news/v1/index.ts
@@ -1,6 +1,7 @@
 import { handleCors } from '../../_shared/cors.js';
 import { getCached } from '../../_shared/cache.js';
 import { jsonResponse, errorResponse } from '../../_shared/error.js';
+import { XMLParser } from 'fast-xml-parser';
 
 export const config = { runtime: 'edge' };
 
@@ -11,7 +12,20 @@ interface RSSItem {
   pubDate?: string;
   description?: string;
   enclosure?: { url?: string };
+  thumbnail?: string;
 }
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  removeNSPrefix: false,
+  parseTagValue: false,
+  trimValues: true,
+  processEntities: true,
+  htmlEntities: true,
+  isArray: (_name: string, jpath: string) =>
+    jpath === 'rss.channel.item' || jpath === 'feed.entry',
+});
 
 export default async function handler(request: Request): Promise<Response> {
   const corsResponse = handleCors(request);
@@ -65,32 +79,100 @@ async function fetchRSSFeed(url: string): Promise<RSSItem[]> {
 }
 
 function parseRSS(xml: string): RSSItem[] {
+  let parsed: Record<string, unknown>;
+  try {
+    // Strip DOCTYPE declarations to prevent external entity errors
+    const sanitized = xml.replace(/<!DOCTYPE\s[^[>]*(?:\[[\s\S]*?\])?[^>]*>/gi, '');
+    parsed = parser.parse(sanitized) as Record<string, unknown>;
+  } catch {
+    return [];
+  }
+
   const items: RSSItem[] = [];
 
-  // Simple regex-based RSS parser (works for both RSS 2.0 and Atom)
-  const itemRegex = /<item>([\s\S]*?)<\/item>|<entry>([\s\S]*?)<\/entry>/g;
-  let match;
+  // RSS 2.0: rss.channel.item[]
+  const channel = (parsed?.rss as Record<string, unknown>)?.channel as Record<string, unknown> | undefined;
+  const rssItems: unknown[] = (channel?.item as unknown[]) ?? [];
 
-  while ((match = itemRegex.exec(xml)) !== null) {
-    const content = match[1] ?? match[2] ?? '';
-    items.push({
-      title: extractTag(content, 'title'),
-      link: extractTag(content, 'link') ?? extractAttr(content, 'link', 'href'),
-      guid: extractTag(content, 'guid') ?? extractTag(content, 'id'),
-      pubDate: extractTag(content, 'pubDate') ?? extractTag(content, 'published') ?? extractTag(content, 'updated'),
-      description: extractTag(content, 'description') ?? extractTag(content, 'summary'),
-    });
+  for (const raw of rssItems) {
+    const item = raw as Record<string, unknown>;
+    const parsed_item: RSSItem = {
+      title: textValue(item.title),
+      link: textValue(item.link),
+      guid: textValue(item.guid),
+      pubDate: textValue(item.pubDate),
+      description: textValue(item.description) ?? textValue(item['content:encoded']),
+      enclosure: extractEnclosure(item),
+      thumbnail: extractThumbnail(item),
+    };
+    if (parsed_item.title || parsed_item.link || parsed_item.guid) {
+      items.push(parsed_item);
+    }
+  }
+
+  // Atom: feed.entry[]
+  const feed = parsed?.feed as Record<string, unknown> | undefined;
+  const atomEntries: unknown[] = (feed?.entry as unknown[]) ?? [];
+
+  for (const raw of atomEntries) {
+    const entry = raw as Record<string, unknown>;
+    const parsed_entry: RSSItem = {
+      title: textValue(entry.title),
+      link: extractAtomLink(entry.link),
+      guid: textValue(entry.id),
+      pubDate: textValue(entry.published) ?? textValue(entry.updated),
+      description: textValue(entry.summary) ?? textValue(entry.content),
+    };
+    if (parsed_entry.title || parsed_entry.link || parsed_entry.guid) {
+      items.push(parsed_entry);
+    }
   }
 
   return items;
 }
 
-function extractTag(content: string, tag: string): string | undefined {
-  const match = content.match(new RegExp(`<${tag}[^>]*><!\\[CDATA\\[([\\s\\S]*?)\\]\\]></${tag}>|<${tag}[^>]*>([\\s\\S]*?)</${tag}>`));
-  return match ? (match[1] ?? match[2])?.trim() : undefined;
+function textValue(val: unknown): string | undefined {
+  if (val == null) return undefined;
+  if (typeof val === 'string') return val.trim() || undefined;
+  if (typeof val === 'number') return String(val);
+  if (typeof val === 'object' && val !== null && '#text' in val) {
+    return String((val as Record<string, unknown>)['#text']).trim() || undefined;
+  }
+  return undefined;
 }
 
-function extractAttr(content: string, tag: string, attr: string): string | undefined {
-  const match = content.match(new RegExp(`<${tag}[^>]*${attr}="([^"]*)"[^>]*/?>`, 'i'));
-  return match?.[1]?.trim();
+function extractEnclosure(item: Record<string, unknown>): { url?: string } | undefined {
+  const enc = item.enclosure as Record<string, unknown> | undefined;
+  if (!enc) return undefined;
+  const url = enc['@_url'];
+  return url ? { url: String(url) } : undefined;
+}
+
+function extractThumbnail(item: Record<string, unknown>): string | undefined {
+  const thumb = item['media:thumbnail'] as Record<string, unknown> | string | undefined;
+  if (thumb) {
+    const url = typeof thumb === 'string' ? thumb : thumb['@_url'];
+    if (url) return String(url);
+  }
+  const media = item['media:content'] as Record<string, unknown> | undefined;
+  if (media) {
+    const url = media['@_url'];
+    if (url) return String(url);
+  }
+  return undefined;
+}
+
+function extractAtomLink(link: unknown): string | undefined {
+  if (!link) return undefined;
+  if (typeof link === 'string') return link;
+  if (typeof link === 'object' && !Array.isArray(link)) {
+    return (link as Record<string, unknown>)['@_href'] as string | undefined;
+  }
+  if (Array.isArray(link)) {
+    const alt = link.find((l: Record<string, unknown>) => l['@_rel'] === 'alternate' && l['@_href']);
+    if (alt) return alt['@_href'] as string;
+    const first = link.find((l: Record<string, unknown>) => l['@_href']);
+    return first?.['@_href'] as string | undefined;
+  }
+  return undefined;
 }

--- a/src/App.ts
+++ b/src/App.ts
@@ -1,6 +1,7 @@
 import { MapEngine, type MapConfig } from './core/map/MapEngine.js';
 import { PanelManager } from './core/panels/PanelManager.js';
 import { SourceManager } from './core/sources/SourceManager.js';
+import type { SourceHealth } from './core/sources/SourceHealth.js';
 import { AIManager, type AIConfig } from './core/ai/AIManager.js';
 import './styles/base.css';
 
@@ -24,6 +25,10 @@ export class App {
       <header class="forge-header">
         <h1 class="forge-title">${config.monitor.name}</h1>
         <div class="forge-header-actions">
+          <span id="forge-health-indicator" class="forge-health-indicator" style="display:none">
+            <span class="forge-health-dot"></span>
+            <span class="forge-health-text"></span>
+          </span>
           <button id="layer-toggle-btn" class="forge-btn">Layers</button>
         </div>
       </header>
@@ -65,6 +70,12 @@ export class App {
     // Wire up source updates to panels
     this.sourceManager.onItems((items) => {
       this.panelManager?.updateAll(items);
+    });
+
+    // Wire up source health to service-status panel and header indicator
+    this.sourceManager.onHealth((health) => {
+      this.panelManager?.updatePanel('service-status', health);
+      this.updateHealthIndicator(health);
     });
 
     // Layer toggle button
@@ -120,6 +131,33 @@ export class App {
         this.mapEngine?.toggleLayer(target.dataset.layer!, target.checked);
       });
     });
+  }
+
+  private updateHealthIndicator(health: Map<string, SourceHealth>): void {
+    const indicator = document.getElementById('forge-health-indicator');
+    if (!indicator) return;
+
+    const entries = Array.from(health.values());
+    const offline = entries.filter(h => h.status === 'offline').length;
+    const degraded = entries.filter(h => h.status === 'degraded').length;
+
+    if (offline === 0 && degraded === 0) {
+      indicator.style.display = 'none';
+      return;
+    }
+
+    indicator.style.display = 'inline-flex';
+    const dot = indicator.querySelector('.forge-health-dot') as HTMLElement;
+    const text = indicator.querySelector('.forge-health-text') as HTMLElement;
+
+    const parts: string[] = [];
+    if (offline > 0) parts.push(`${offline} offline`);
+    if (degraded > 0) parts.push(`${degraded} degraded`);
+
+    dot.className = offline > 0
+      ? 'forge-health-dot status-red'
+      : 'forge-health-dot status-yellow';
+    text.textContent = parts.join(', ');
   }
 
   destroy(): void {

--- a/src/core/panels/types/ServiceStatusPanel.test.ts
+++ b/src/core/panels/types/ServiceStatusPanel.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ServiceStatusPanel } from './ServiceStatusPanel.js';
+import type { SourceHealth } from '../../sources/SourceHealth.js';
+
+const makePanel = () => {
+  const container = document.createElement('div');
+  const panel = new ServiceStatusPanel(container, {
+    name: 'service-status',
+    type: 'service-status',
+    displayName: 'Source Health',
+    position: 0,
+    config: {},
+  });
+  panel.render();
+  return { panel, container };
+};
+
+describe('ServiceStatusPanel', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders service status from health Map', () => {
+    const { panel, container } = makePanel();
+    const health = new Map<string, SourceHealth>([
+      ['feed-a', { status: 'online', lastSuccess: new Date(), lastError: null, consecutiveFailures: 0 }],
+      ['feed-b', { status: 'offline', lastSuccess: null, lastError: 'timeout', consecutiveFailures: 3 }],
+    ]);
+    panel.update(health);
+    const items = container.querySelectorAll('.service-item');
+    expect(items).toHaveLength(2);
+    expect(items[0].querySelector('.service-name')?.textContent).toBe('feed-a');
+    expect(items[1].querySelector('.service-name')?.textContent).toBe('feed-b');
+  });
+
+  it('shows correct dot colors for each status', () => {
+    const { panel, container } = makePanel();
+    const health = new Map<string, SourceHealth>([
+      ['online-src', { status: 'online', lastSuccess: new Date(), lastError: null, consecutiveFailures: 0 }],
+      ['degraded-src', { status: 'degraded', lastSuccess: null, lastError: 'err', consecutiveFailures: 1 }],
+      ['offline-src', { status: 'offline', lastSuccess: null, lastError: 'err', consecutiveFailures: 5 }],
+    ]);
+    panel.update(health);
+    const dots = container.querySelectorAll('.service-dot');
+    expect(dots[0].classList.contains('status-green')).toBe(true);
+    expect(dots[1].classList.contains('status-yellow')).toBe(true);
+    expect(dots[2].classList.contains('status-red')).toBe(true);
+  });
+
+  it('handles empty health map', () => {
+    const { panel, container } = makePanel();
+    panel.update(new Map());
+    const items = container.querySelectorAll('.service-item');
+    expect(items).toHaveLength(0);
+  });
+});

--- a/src/core/panels/types/ServiceStatusPanel.ts
+++ b/src/core/panels/types/ServiceStatusPanel.ts
@@ -1,11 +1,12 @@
 import DOMPurify from 'dompurify';
 import { PanelBase } from '../PanelBase.js';
+import type { SourceHealth } from '../../sources/SourceHealth.js';
 
 interface ServiceStatus {
   name: string;
   status: 'online' | 'degraded' | 'offline';
   lastUpdate: string;
-  itemCount: number;
+  failures: number;
 }
 
 export class ServiceStatusPanel extends PanelBase {
@@ -20,6 +21,20 @@ export class ServiceStatusPanel extends PanelBase {
   }
 
   update(data: unknown): void {
+    if (data instanceof Map) {
+      this.services = Array.from(
+        (data as Map<string, SourceHealth>).entries(),
+      ).map(([name, health]) => ({
+        name,
+        status: health.status,
+        lastUpdate: health.lastSuccess
+          ? health.lastSuccess.toLocaleTimeString()
+          : 'never',
+        failures: health.consecutiveFailures,
+      }));
+      this.renderStatus();
+      return;
+    }
     if (!Array.isArray(data)) return;
     this.services = data as ServiceStatus[];
     this.renderStatus();
@@ -32,11 +47,14 @@ export class ServiceStatusPanel extends PanelBase {
     itemsEl.innerHTML = this.services.map(s => {
       const dot = s.status === 'online' ? 'status-green'
         : s.status === 'degraded' ? 'status-yellow' : 'status-red';
+      const meta = s.status === 'online'
+        ? s.lastUpdate
+        : `${s.failures} failure${s.failures !== 1 ? 's' : ''}`;
       return `
         <div class="service-item">
           <span class="service-dot ${dot}"></span>
           <span class="service-name">${DOMPurify.sanitize(s.name)}</span>
-          <span class="service-count">${s.itemCount} items</span>
+          <span class="service-meta">${DOMPurify.sanitize(meta)}</span>
         </div>
       `;
     }).join('');

--- a/src/core/sources/SourceHealth.ts
+++ b/src/core/sources/SourceHealth.ts
@@ -1,0 +1,6 @@
+export interface SourceHealth {
+  status: 'online' | 'degraded' | 'offline';
+  lastSuccess: Date | null;
+  lastError: string | null;
+  consecutiveFailures: number;
+}

--- a/src/core/sources/SourceManager.test.ts
+++ b/src/core/sources/SourceManager.test.ts
@@ -5,14 +5,16 @@ import { SourceBase, type SourceItem, type SourceConfig } from './SourceBase.js'
 
 class MockSource extends SourceBase {
   items: SourceItem[] = [];
+  shouldThrow = false;
   async fetch(): Promise<SourceItem[]> {
+    if (this.shouldThrow) throw new Error('mock error');
     return this.items;
   }
 }
 
-const makeConfig = (name: string): SourceConfig => ({
+const makeConfig = (name: string, interval = 3600): SourceConfig => ({
   name, type: 'mock-mgr', url: 'https://example.com',
-  interval: 3600, category: 'test', tier: 3, tags: [], language: 'en',
+  interval, category: 'test', tier: 3, tags: [], language: 'en',
 });
 
 beforeEach(() => {
@@ -80,14 +82,129 @@ describe('SourceManager', () => {
     expect(listener).toHaveBeenCalled();
   });
 
-  it('stopAll clears all timers', () => {
+  it('stopAll clears all timers', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const manager = new SourceManager();
     manager.initialize([makeConfig('e')]);
     manager.startAll();
+    // Flush microtasks so the initial poll() resolves and sets setTimeout
+    await vi.advanceTimersByTimeAsync(0);
     expect(vi.getTimerCount()).toBeGreaterThan(0);
     manager.stopAll();
     expect(vi.getTimerCount()).toBe(0);
     // Advance time — no callbacks should fire (no errors thrown)
-    vi.advanceTimersByTime(7200_000);
+    await vi.advanceTimersByTimeAsync(7200_000);
+    warnSpy.mockRestore();
+  });
+
+  // ─── Health Tracking ───────────────────────────────
+
+  it('records health as online after successful fetch', async () => {
+    const manager = new SourceManager();
+    manager.initialize([makeConfig('h1')]);
+    const src = manager.getSource('h1') as MockSource;
+    src.items = [{ id: '1', title: 'X', url: '', source: 'h1', category: 'test', timestamp: new Date() }];
+
+    await manager.fetchAll();
+    const health = manager.getHealth().get('h1')!;
+    expect(health.status).toBe('online');
+    expect(health.consecutiveFailures).toBe(0);
+    expect(health.lastSuccess).toBeInstanceOf(Date);
+  });
+
+  it('records health as degraded after 1 failure', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const manager = new SourceManager();
+    manager.initialize([makeConfig('h2')]);
+    const src = manager.getSource('h2') as MockSource;
+    src.shouldThrow = true;
+
+    await manager.fetchAll();
+    const health = manager.getHealth().get('h2')!;
+    expect(health.status).toBe('degraded');
+    expect(health.consecutiveFailures).toBe(1);
+    expect(health.lastError).toBe('mock error');
+    warnSpy.mockRestore();
+  });
+
+  it('records health as offline after 3 consecutive failures', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const manager = new SourceManager();
+    manager.initialize([makeConfig('h3')]);
+    const src = manager.getSource('h3') as MockSource;
+    src.shouldThrow = true;
+
+    await manager.fetchAll();
+    await manager.fetchAll();
+    await manager.fetchAll();
+    const health = manager.getHealth().get('h3')!;
+    expect(health.status).toBe('offline');
+    expect(health.consecutiveFailures).toBe(3);
+    warnSpy.mockRestore();
+  });
+
+  it('resets health to online after recovery', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const manager = new SourceManager();
+    manager.initialize([makeConfig('h4')]);
+    const src = manager.getSource('h4') as MockSource;
+    src.items = [{ id: '1', title: 'X', url: '', source: 'h4', category: 'test', timestamp: new Date() }];
+
+    src.shouldThrow = true;
+    await manager.fetchAll();
+    await manager.fetchAll();
+    expect(manager.getHealth().get('h4')!.status).toBe('degraded');
+
+    src.shouldThrow = false;
+    await manager.fetchAll();
+    const health = manager.getHealth().get('h4')!;
+    expect(health.status).toBe('online');
+    expect(health.consecutiveFailures).toBe(0);
+    warnSpy.mockRestore();
+  });
+
+  it('notifies health listeners on status change', async () => {
+    const manager = new SourceManager();
+    manager.initialize([makeConfig('h5')]);
+    const src = manager.getSource('h5') as MockSource;
+    src.items = [{ id: '1', title: 'X', url: '', source: 'h5', category: 'test', timestamp: new Date() }];
+
+    const healthListener = vi.fn();
+    manager.onHealth(healthListener);
+
+    await manager.fetchAll();
+    expect(healthListener).toHaveBeenCalledTimes(1);
+    const healthMap = healthListener.mock.calls[0][0] as Map<string, unknown>;
+    expect(healthMap).toBeInstanceOf(Map);
+    expect(healthMap.has('h5')).toBe(true);
+  });
+
+  it('uses exponential backoff on failure in startSource', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const manager = new SourceManager();
+    const interval = 60; // 60 seconds
+    manager.initialize([makeConfig('h6', interval)]);
+    const src = manager.getSource('h6') as MockSource;
+    src.shouldThrow = true;
+
+    manager.startAll();
+
+    // Initial poll runs immediately (microtask)
+    await vi.advanceTimersByTimeAsync(0);
+    // After 1st failure: backoff = 60 * 2^1 = 120s
+    expect(manager.getHealth().get('h6')!.consecutiveFailures).toBe(1);
+
+    // Advance 120s for the 2nd poll
+    await vi.advanceTimersByTimeAsync(120_000);
+    // After 2nd failure: backoff = 60 * 2^2 = 240s
+    expect(manager.getHealth().get('h6')!.consecutiveFailures).toBe(2);
+
+    // Advance 240s for the 3rd poll
+    await vi.advanceTimersByTimeAsync(240_000);
+    expect(manager.getHealth().get('h6')!.consecutiveFailures).toBe(3);
+    expect(manager.getHealth().get('h6')!.status).toBe('offline');
+
+    manager.stopAll();
+    warnSpy.mockRestore();
   });
 });

--- a/src/core/sources/SourceManager.ts
+++ b/src/core/sources/SourceManager.ts
@@ -1,16 +1,27 @@
 import type { SourceBase, SourceItem, SourceConfig } from './SourceBase.js';
+import type { SourceHealth } from './SourceHealth.js';
 import { createSource } from './source-registry.js';
+
+const MAX_BACKOFF_SECONDS = 300;
 
 export class SourceManager {
   private sources = new Map<string, SourceBase>();
-  private timers = new Map<string, ReturnType<typeof setInterval>>();
+  private timers = new Map<string, ReturnType<typeof setTimeout>>();
   private listeners: Array<(items: SourceItem[], sourceName: string) => void> = [];
+  private health = new Map<string, SourceHealth>();
+  private healthListeners: Array<(health: Map<string, SourceHealth>) => void> = [];
 
   initialize(configs: SourceConfig[]): void {
     for (const config of configs) {
       try {
         const source = createSource(config);
         this.sources.set(config.name, source);
+        this.health.set(config.name, {
+          status: 'online',
+          lastSuccess: null,
+          lastError: null,
+          consecutiveFailures: 0,
+        });
       } catch (err) {
         console.warn(`Failed to create source "${config.name}":`, err);
       }
@@ -25,13 +36,21 @@ export class SourceManager {
 
   stopAll(): void {
     for (const timer of this.timers.values()) {
-      clearInterval(timer);
+      clearTimeout(timer);
     }
     this.timers.clear();
   }
 
   onItems(listener: (items: SourceItem[], sourceName: string) => void): void {
     this.listeners.push(listener);
+  }
+
+  onHealth(listener: (health: Map<string, SourceHealth>) => void): void {
+    this.healthListeners.push(listener);
+  }
+
+  getHealth(): Map<string, SourceHealth> {
+    return new Map(this.health);
   }
 
   async fetchAll(): Promise<SourceItem[]> {
@@ -41,8 +60,11 @@ export class SourceManager {
         const items = await source.fetchWithCache();
         allItems.push(...items);
         this.notifyListeners(items, name);
+        this.recordSuccess(name);
       } catch (err) {
-        console.warn(`Error fetching source "${name}":`, err);
+        const errMsg = err instanceof Error ? err.message : String(err);
+        console.warn(`Error fetching source "${name}":`, errMsg);
+        this.recordFailure(name, errMsg);
       }
     });
     await Promise.allSettled(promises);
@@ -58,29 +80,65 @@ export class SourceManager {
   }
 
   private startSource(name: string, source: SourceBase): void {
-    // Initial fetch
-    source.fetchWithCache().then(items => {
-      this.notifyListeners(items, name);
-    }).catch(err => {
-      console.warn(`Initial fetch failed for "${name}":`, err);
-    });
-
-    // Set up periodic refresh
-    const timer = setInterval(async () => {
+    const poll = async () => {
       try {
         const items = await source.fetchWithCache();
         this.notifyListeners(items, name);
+        this.recordSuccess(name);
+        const timer = setTimeout(poll, source.getInterval() * 1000);
+        this.timers.set(name, timer);
       } catch (err) {
-        console.warn(`Refresh failed for "${name}":`, err);
+        const errMsg = err instanceof Error ? err.message : String(err);
+        console.warn(`Fetch failed for "${name}":`, errMsg);
+        this.recordFailure(name, errMsg);
+        const health = this.health.get(name)!;
+        const backoffSeconds = Math.min(
+          source.getInterval() * Math.pow(2, health.consecutiveFailures),
+          MAX_BACKOFF_SECONDS,
+        );
+        const timer = setTimeout(poll, backoffSeconds * 1000);
+        this.timers.set(name, timer);
       }
-    }, source.getInterval() * 1000);
+    };
 
-    this.timers.set(name, timer);
+    poll();
+  }
+
+  private recordSuccess(name: string): void {
+    const prev = this.health.get(name);
+    if (!prev) return;
+    this.health.set(name, {
+      status: 'online',
+      lastSuccess: new Date(),
+      lastError: prev.lastError,
+      consecutiveFailures: 0,
+    });
+    this.notifyHealthListeners();
+  }
+
+  private recordFailure(name: string, error: string): void {
+    const prev = this.health.get(name);
+    if (!prev) return;
+    const failures = prev.consecutiveFailures + 1;
+    this.health.set(name, {
+      status: failures >= 3 ? 'offline' : 'degraded',
+      lastSuccess: prev.lastSuccess,
+      lastError: error,
+      consecutiveFailures: failures,
+    });
+    this.notifyHealthListeners();
   }
 
   private notifyListeners(items: SourceItem[], sourceName: string): void {
     for (const listener of this.listeners) {
       listener(items, sourceName);
+    }
+  }
+
+  private notifyHealthListeners(): void {
+    const snapshot = new Map(this.health);
+    for (const listener of this.healthListeners) {
+      listener(snapshot);
     }
   }
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -62,6 +62,31 @@ html, body {
 
 .forge-btn:hover { border-color: var(--accent); }
 
+/* Health Indicator */
+.forge-health-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.75rem;
+  color: var(--fg);
+  background: rgba(255,255,255,0.05);
+  border-radius: var(--radius);
+  margin-right: 0.5rem;
+}
+
+.forge-health-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  animation: health-pulse 2s ease-in-out infinite;
+}
+
+@keyframes health-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
 /* Main layout */
 .forge-main {
   flex: 1;


### PR DESCRIPTION
## Summary

Resolves #7 — Source resilience: silent failures break core monitoring UX.

### Source Health Tracking
- **`SourceHealth` interface** (`online` / `degraded` / `offline`) with failure count, last success, last error
- **Exponential backoff** in `SourceManager.startSource()`: replaces `setInterval` with `setTimeout` chain. On failure, delay doubles up to 5min cap. After 3 consecutive failures → `offline`
- **`onHealth()` listener API** for reactive health updates
- **`ServiceStatusPanel`** now receives real health data (`Map<string, SourceHealth>`) instead of broken `SourceItem[]` passthrough — shows colored dots (green/yellow/red) with failure count or last success time
- **Header health indicator** — pulsing dot + text badge ("2 offline, 1 degraded") appears when any source is unhealthy

### RSS Parser Upgrade
- Replaced regex-based XML parser (`extractTag`/`extractAttr`) with **`fast-xml-parser`** v5 (already a dependency, previously unused)
- Supports **XML namespaces** (`media:content`, `media:thumbnail`, `dc:creator`)
- Proper **HTML entity decoding** (`&amp;`, `&lt;`, `&nbsp;`)
- Handles both **RSS 2.0** and **Atom** feeds with correct `<link>` attribute extraction
- Strips DOCTYPE declarations for XXE safety; filters empty items from malformed XML
- Added `thumbnail` and `enclosure` extraction from media namespace tags

## Test plan

- [x] All 13 existing RSS parser tests pass (regression safety from PR #8)
- [x] 4 new RSS tests: enclosure extraction, media:thumbnail, HTML entities, multi-link Atom
- [x] 6 new SourceManager tests: health online/degraded/offline, recovery, health listeners, exponential backoff
- [x] 3 new ServiceStatusPanel tests: health Map rendering, dot colors, empty map
- [x] Full suite: **436 tests passing** (27 test files)
- [x] `npx tsc --noEmit` — typecheck passes
- [x] `forge validate` — config valid
- [x] `forge build --skip-vite` — build succeeds

Generated with [Claude Code](https://claude.com/claude-code)