### PR TITLE
docs: update documentation for v0.5.0 release

### DIFF
--- a/.claude/skills/adding-data-sources/SKILL.md
+++ b/.claude/skills/adding-data-sources/SKILL.md
@@ -3,6 +3,28 @@
 ## Trigger
 User wants to add RSS feeds, API sources, or WebSocket connections to their monitor.
 
+## Recommended: Add from Curated Library
+
+The fastest way to add sources is from the built-in library of 244 curated RSS feeds (20 categories) and 20 public API templates.
+
+```bash
+# Browse available library feeds by category
+npx tsx forge/bin/forge.ts source list-library --category tech --format json
+
+# Add a feed from the curated library (idempotent with --upsert)
+npx tsx forge/bin/forge.ts source add rss --from-library <feed-id> --upsert
+
+# Browse available API templates
+npx tsx forge/bin/forge.ts source list-templates --format json
+
+# Add a source from an API template
+npx tsx forge/bin/forge.ts source add rest-api --from-template <template-id> --upsert
+```
+
+Library feeds include pre-configured URLs, categories, tiers, and propaganda risk metadata. Use `list-library` and `list-templates` to discover available IDs.
+
+For sources not in the library, use the manual add commands below.
+
 ## Source Types
 
 | Type | Use Case | Example |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,18 @@ npx tsx forge/bin/forge.ts setup --template tech-minimal --name "My Dashboard" -
 npx tsx forge/bin/forge.ts source add rss --name my-feed --url https://example.com/rss --category news --upsert
 npx tsx forge/bin/forge.ts panel add news-feed --name my-panel --display-name "My Panel" --upsert
 npx tsx forge/bin/forge.ts view add main --display-name "Main" --panels "my-panel" --default --upsert
+
+# Add source from curated library (244 feeds across 20 categories)
+npx tsx forge/bin/forge.ts source add rss --from-library hn-front-page --upsert
+
+# Add source from public API template (20 templates: USGS, NASA, GDELT, etc.)
+npx tsx forge/bin/forge.ts source add rest-api --from-template usgs-earthquakes --upsert
+
+# Browse available library feeds by category
+npx tsx forge/bin/forge.ts source list-library --category tech
+
+# Apply a declarative config patch (merge-by-name, dry-run first)
+npx tsx forge/bin/forge.ts apply patch.json --dry-run
 ```
 
 ## Error Recovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,39 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.5.0] - 2026-03-31
+
+### Added
+
+- 244 curated RSS feeds library across 20 categories with propaganda risk metadata
+- 20 public API source templates (USGS, NASA, GDELT, CoinGecko, etc.)
+- `forge source add --from-library` and `--from-template` commands for batch source imports
+- `forge source list-library` and `list-templates` commands for browsing available sources
+- `forge apply` declarative config patching command (merge-by-name, delete markers, dry-run)
+- `npx create-monitor-forge` scaffolding package with interactive and non-interactive modes
+- 4 new presets: commodity-minimal, commodity-full, happy-minimal, happy-full (19 total)
+- Experimental `forge gh-bridge` command for GitHub CLI data source integration
+- Polling scheduler with stagger, jitter, and concurrency control for SourceManager
+- CI per-preset validation in GitHub Actions pipeline
+- Feed verification script (`scripts/verify-feeds.ts`) for RSS feed liveness checks
+- seenIds memory cap (10,000 per source) preventing unbounded memory growth
+
+### Changed
+
+- SourceManager.startAll() now delegates to polling scheduler instead of firing all fetches simultaneously
+- SourceManager.fetchAll() now respects concurrency limit (max 5 concurrent fetches)
+- RSS handler gracefully degrades on partial feed failures instead of returning 500
+
+### Removed
+
+- `preset apply --merge` flag (was dead code, never implemented; use `forge apply` instead)
+
 ## [0.1.0] - 2026-03-04
 
 ### Added
 
 - CLI-driven dashboard configuration with 11 forge commands
-- 7 presets: tech, finance, geopolitics (minimal & full) + blank canvas
+- 7 initial presets: tech, finance, geopolitics (minimal & full) + blank canvas
 - 6 panel types: news-feed, ai-brief, market-ticker, entity-tracker, instability-index, service-status
 - 5 map layer types: points, lines, polygons, heatmap, hexagon
 - 3 data source types: RSS, REST API, WebSocket

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The first agent-native dashboard framework — designed for [Claude Code](https:
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D18-green.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue.svg)](https://www.typescriptlang.org/)
-[![GitHub release](https://img.shields.io/github/v/release/alohays/monitor-forge)](https://github.com/alohays/monitor-forge/releases)
+[![v0.5.0](https://img.shields.io/badge/version-0.5.0-brightgreen)](https://github.com/alohays/monitor-forge/releases/tag/v0.5.0)
 
 <p>
   <a href="#-quick-start"><img src="https://img.shields.io/badge/Quick_Start-blue?style=for-the-badge" alt="Quick Start"></a>
@@ -42,12 +42,21 @@ The first agent-native dashboard framework — designed for [Claude Code](https:
 | Setup time | N/A (single purpose) | Hours to days | **Minutes** |
 | Customization | Edit source code | Edit source code | **CLI commands** |
 | AI agent support | None | None | **Native** (AGENTS.md, Skills) |
-| Domain presets | 1 | 1 per fork | **15 included** |
+| Domain presets | 1 | 1 per fork | **19 included** |
 | AI analysis | None | DIY | **Built-in** (Groq/OpenRouter) |
 | Adding sources | Edit code | Edit code | **`forge source add`** |
 | Deploy | Manual | Manual | **One-click** (Vercel) |
 
 ## 🚀 Quick Start
+
+```bash
+npx create-monitor-forge my-dashboard
+cd my-dashboard
+npm install
+npm run dev    # dashboard at http://localhost:5173
+```
+
+Or clone the repo directly:
 
 ```bash
 git clone https://github.com/YOUR_USERNAME/monitor-forge.git my-monitor
@@ -112,8 +121,8 @@ All customization via `forge` commands. `--format json` for seamless AI agent in
 </td>
 <td width="33%" valign="top">
 
-### 📋 15 Domain Presets
-Pre-built configs across 8 domains: tech, finance, geopolitics, climate, cyber, health, korea. From blank canvas to full setup.
+### 📋 19 Domain Presets
+Pre-built configs across 10 domains: tech, finance, geopolitics, climate, cyber, health, korea, commodity, happy. From blank canvas to full setup.
 
 </td>
 <td width="33%" valign="top">
@@ -143,6 +152,26 @@ Vercel Edge Functions with security headers, CSP, and proxy domain allowlist. RS
 
 </td>
 </tr>
+<tr>
+<td width="33%" valign="top">
+
+### 📰 244 Curated RSS Feeds
+Browse and add from a curated library of 244 RSS feeds across 20 categories — no URL hunting required.
+
+</td>
+<td width="33%" valign="top">
+
+### 🔌 20 API Templates
+Pre-configured API source templates for popular services. Add with a single command.
+
+</td>
+<td width="33%" valign="top">
+
+### 📝 Declarative Config Patching
+Apply bulk configuration changes with `forge apply` — describe your desired state in a patch file.
+
+</td>
+</tr>
 </table>
 
 ## 📦 Available Presets
@@ -167,6 +196,31 @@ Vercel Edge Functions with security headers, CSP, and proxy domain allowlist. RS
 | `health-full` | health | 7 | 4 | + Lancet, CDC Newsroom, bioRxiv, Global Health Now |
 | `korea-minimal` | korea | 3 | 2 | Yonhap English, Korea Herald, BBC Asia |
 | `korea-full` | korea | 7 | 4 | + NK News, Hankyoreh, Reuters Asia, Korea Times |
+| `commodity-minimal` | commodity | 7 RSS | 2 | Basic commodity tracking |
+| `commodity-full` | commodity | 17 RSS + API | 4 | Full commodity intelligence with AI |
+| `happy-minimal` | happy | 7 RSS | 2 | Curated positive news |
+| `happy-full` | happy | 16 RSS | 4 | Comprehensive positive news with AI |
+
+## 📚 Data Library
+
+monitor-forge ships with a curated data library so you can add sources without hunting for URLs:
+
+- **244 RSS Feeds** across 20 categories (tech, finance, science, health, world news, and more)
+- **20 API Templates** for popular services (weather, crypto, earthquake, air quality, and more)
+
+```bash
+# Browse available RSS feeds
+npm run forge -- source list-library
+
+# Add a feed from the library by ID
+npm run forge -- source add --from-library reuters-world
+
+# Browse API templates
+npm run forge -- source list-templates
+
+# Add an API source from a template
+npm run forge -- source add --from-template openweathermap
+```
 
 ## 📡 Workflow & Data Flow
 
@@ -332,7 +386,13 @@ flowchart LR
 | `forge env check/generate` | Manage environment variables |
 | `forge build` | Build for production |
 | `forge dev` | Start development server |
+| `forge apply <file>` | Apply declarative config patch |
+| `forge source list-library` | Browse 244 curated RSS feeds |
+| `forge source list-templates` | Browse 20 API templates |
+| `forge source add --from-library <id>` | Add source from curated library |
+| `forge source add --from-template <id>` | Add source from API template |
 | `forge deploy` | Deploy to Vercel |
+| `forge gh-bridge` *(experimental)* | GitHub CLI bridge PoC |
 
 ## 🔧 Tech Stack
 
@@ -351,7 +411,7 @@ monitor-forge/
 │   ├── core/              # Map, panels, sources, AI engines
 │   └── styles/            # CSS + themes
 ├── ☁️ api/                # Vercel Edge Functions
-├── 📋 presets/            # 15 preset templates (8 domains)
+├── 📋 presets/            # 19 preset templates (10 domains)
 ├── 🗺️ data/geo/           # GeoJSON data files
 ├── 🤖 .claude/skills/     # 5 Claude Code Skills
 ├── 📝 .skills/            # 2 workflow guides


### PR DESCRIPTION
## Summary

Update all documentation to reflect v0.5.0 features.

### Changes

**README.md:**
- Added `npx create-monitor-forge` as primary quick start method
- Updated preset table: 15 → 19 presets (added commodity + happy)
- Added Data Library section (244 RSS feeds, 20 API templates)
- Updated CLI reference with new commands (apply, list-library, list-templates, from-library, from-template, gh-bridge)
- Updated feature highlights and counts

**CHANGELOG.md:**
- Added complete v0.5.0 entry (12 additions, 3 changes, 1 removal)

**AGENTS.md:**
- Added `--from-library` and `--from-template` examples to Quick Start
- Added `forge apply` example

**.claude/skills/adding-data-sources/SKILL.md:**
- Added curated library as recommended method for adding sources

## Test Plan
- [x] All documentation in English
- [x] Feature counts verified (19 presets, 244 feeds, 20 templates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)